### PR TITLE
Fix Dataset.from_config

### DIFF
--- a/scaaml/io/dataset.py
+++ b/scaaml/io/dataset.py
@@ -54,6 +54,11 @@ class Dataset():
             True set self.path = root_path, self.root_path to be the parent of
             self.path. In this case it does not necessarily hold that
             self.path.name == self.slug (the directory could have been renamed).
+
+        Raises:
+          ValueError: If firmware_sha256 evaluates to False.
+          FileExistsError: If creating this object would overwrite the
+            corresponding config file.
         """
         self.shortname = shortname
         self.architecture = architecture
@@ -81,9 +86,10 @@ class Dataset():
             self.root_path = root_path
             self.path = Path(self.root_path) / self.slug
             # create directory -- check if its empty
-            if self.path.exists():
-                cprint("[Warning] Path exist, some files might be over-written",
-                       'yellow')
+            if Dataset._get_config_path(self.path).exists():
+                raise FileExistsError(f'Dataset info file exists and would be '
+                                      f'overwritten. Use instead: Dataset.from'
+                                      f'_config(dataset_path="{self.path}")')
             else:
                 # create path if needed
                 self.path.mkdir(parents=True)

--- a/scaaml/io/dataset.py
+++ b/scaaml/io/dataset.py
@@ -42,8 +42,17 @@ class Dataset():
         capture_info: dict = {},
         min_values: Dict[str, int] = {},
         max_values: Dict[str, int] = {},
+        from_config: bool = False,
     ) -> None:
-        self.root_path = root_path
+        """Class for saving and loading a database.
+
+        Args:
+          from_config: This Dataset object has been created from a saved
+            config, root_path thus points to what should be self.path. When
+            True set self.path = root_path, self.root_path to be the parent of
+            self.path. In this case it does not necessarily hold that
+            self.path.name == self.slug (the directory could have been renamed).
+        """
         self.shortname = shortname
         self.architecture = architecture
         self.implementation = implementation
@@ -61,19 +70,24 @@ class Dataset():
         if not self.firmware_sha256:
             raise ValueError("Firmware hash is required")
 
-        # create directory -- check if its empty
         self.slug = "%s_%s_%s_v%s_%s" % (shortname, algorithm, architecture,
                                          implementation, version)
-        self.path = Path(self.root_path) / self.slug
-        if self.path.exists():
-            cprint("[Warning] Path exist, some files might be over-written",
-                   'yellow')
+        if from_config:
+            self.path = Path(root_path)
+            self.root_path = str(self.path.parent)
         else:
-            # create path if needed
-            self.path.mkdir(parents=True)
-            Path(self.path / 'train').mkdir()
-            Path(self.path / 'test').mkdir()
-            Path(self.path / 'holdout').mkdir()
+            self.root_path = root_path
+            self.path = Path(self.root_path) / self.slug
+            # create directory -- check if its empty
+            if self.path.exists():
+                cprint("[Warning] Path exist, some files might be over-written",
+                       'yellow')
+            else:
+                # create path if needed
+                self.path.mkdir(parents=True)
+                Path(self.path / 'train').mkdir()
+                Path(self.path / 'test').mkdir()
+                Path(self.path / 'holdout').mkdir()
 
         cprint("Dataset path: %s" % self.path, 'green')
 
@@ -108,8 +122,9 @@ class Dataset():
                 self.min_values[k] = math.inf
                 self.max_values[k] = 0
 
-        # write config
-        self._write_config()
+        # write config if needed
+        if not from_config:
+            self._write_config()
 
     @staticmethod
     def _shard_name(shard_group: int, shard_key: str, shard_part: int) -> str:
@@ -717,6 +732,7 @@ class Dataset():
             examples_per_shard=config['examples_per_shard'],
             min_values=config['min_values'],
             max_values=config['max_values'],
+            from_config=True,
         )
 
     @staticmethod

--- a/scaaml/io/errors.py
+++ b/scaaml/io/errors.py
@@ -1,0 +1,22 @@
+"""Implement an error to indicate that a scaaml.io.Dataset already exists.
+
+Creating scaaml.io.Dataset should not overwrite existing files. When it could
+the constructor needs to raise an error, which should also contain the dataset
+directory.
+"""
+
+from pathlib import Path
+
+
+class DatasetExistsError(FileExistsError):
+    """Error for signalling that the dataset already exists."""
+    def __init__(self, dataset_path: Path) -> None:
+        """Represents that the dataset already exists.
+
+        Args:
+          dataset_path: The dataset path.
+        """
+        super().__init__(
+            f'Dataset info file exists and would be overwritten. Use instead:'
+            f' Dataset.from_config(dataset_path="{dataset_path}")')
+        self.dataset_path = dataset_path

--- a/tests/io/test_dataset.py
+++ b/tests/io/test_dataset.py
@@ -10,6 +10,29 @@ from scaaml.io.shard import Shard
 from scaaml.io import utils as siutils
 
 
+def test_from_config(tmp_path):
+    # Create the file structure.
+    d1 = Dataset(root_path=tmp_path,
+                 shortname='shortname',
+                 architecture='architecture',
+                 implementation='implementation',
+                 algorithm='algorithm',
+                 version=1,
+                 description='description',
+                 url='',
+                 firmware_sha256='abc123',
+                 examples_per_shard=64,
+                 measurements_info={},
+                 attack_points_info={})
+    old_files = set(tmp_path.glob('**/*'))
+
+    d2 = Dataset.from_config(d1.path)
+
+    # No new files have been created.
+    new_files = set(tmp_path.glob('**/*'))
+    assert old_files == new_files
+
+
 def test_close_shard(tmp_path):
     minfo = {
         "trace1": {

--- a/tests/io/test_dataset.py
+++ b/tests/io/test_dataset.py
@@ -10,6 +10,30 @@ from scaaml.io.shard import Shard
 from scaaml.io import utils as siutils
 
 
+def test_info_file_raises(tmp_path):
+    # Make the dataset directory with info.json in it (the 'sn_al_ar_vimp_1' is
+    # the slug).
+    dpath = tmp_path / 'sn_al_ar_vimp_1'
+    dpath.mkdir()
+    Dataset._get_config_path(dpath).write_text('exists')
+
+    with pytest.raises(FileExistsError) as verror:
+        ds = Dataset(root_path=tmp_path,
+                     shortname='sn',
+                     architecture='ar',
+                     implementation='imp',
+                     algorithm='al',
+                     version=1,
+                     description='description',
+                     url='',
+                     firmware_sha256='abc123',
+                     examples_per_shard=1,
+                     measurements_info={},
+                     attack_points_info={})
+    assert ('Dataset info file exists and would be overwritten. '
+            'Use instead:') in str(verror.value)
+
+
 def test_from_loaded_json(tmp_path):
     ds = Dataset(root_path=tmp_path,
                  shortname='shortname',


### PR DESCRIPTION
When called, Dataset.from_config would create another directory structure
inside the dataset directory and point self.path there. This commit
fixes this behavior even when the dataset root directory has been
renamed to something else than self.slug.