### PR TITLE
Allow SScope to have unused keyword arguments

### DIFF
--- a/scaaml/capture/aes/scope.py
+++ b/scaaml/capture/aes/scope.py
@@ -5,7 +5,7 @@ import chipwhisperer as cw
 class SScope:
     """Scope context manager."""
     def __init__(self, gain: int, samples: int, offset: int, clock: int,
-                 sample_rate: str):
+                 sample_rate: str, **_):
         """Create scope context.
 
         Args:
@@ -14,6 +14,23 @@ class SScope:
           offset: Number of samples to wait before starting recording data.
           clock: CLKGEN output frequency (in Hz).
           sample_rate: Clock source for cw.ClockSettings.adc_src.
+          _: SScope is expected to be initialized using the capture_info
+            dictionary which may contain extra keys (additional information
+            about the capture; the capture_info dictionary is saved in the
+            info file of the dataset). Thus we can ignore the rest of keyword
+            arguments.
+
+        Expected use:
+          capture_info = {
+              'gain': gain,
+              'samples': samples,
+              'offset': offset,
+              'clock': clock,
+              'sample_rate': sample_rate,
+              'other_information': 'Can also be present.',
+          }
+          with SScope(**capture_info) as scope:
+              # Use the scope object.
         """
         self._scope = None
         self._gain = gain

--- a/tests/capture/aes/test_scope.py
+++ b/tests/capture/aes/test_scope.py
@@ -15,6 +15,41 @@ def test_with(mock_scope):
     clock = 7372800
     sample_rate = 'clkgen_x4'
     mock_cwscope.adc.oa.hwInfo.maxSamples.return_value = -1
+    capture_info = {
+        'gain': gain,
+        'samples': samples,
+        'offset': offset,
+        'clock': clock,
+        'sample_rate': sample_rate,
+        'other_information': 'Can also be present.',
+    }
+
+    with SScope(**capture_info) as scope:
+        assert scope.scope == mock_cwscope
+        assert mock_cwscope.dis.call_count == 0
+        assert mock_cwscope.gain.db == gain
+        assert mock_cwscope.adc.samples == samples
+        assert mock_cwscope.adc.offset == offset
+        assert mock_cwscope.adc.basic_mode == "rising_edge"
+        assert mock_cwscope.clock.clkgen_freq == clock
+        assert mock_cwscope.trigger.triggers == "tio4"
+        assert mock_cwscope.clock.adc_src == sample_rate
+        assert mock_cwscope.clock.freq_ctr_src == "clkgen"
+        assert mock_cwscope.adc.presamples == 0
+
+    assert mock_cwscope.dis.call_count >= 1
+
+
+@patch.object(cw, 'scope')
+def test_with(mock_scope):
+    mock_cwscope = MagicMock()
+    mock_scope.return_value = mock_cwscope
+    gain = 45
+    samples = 7000
+    offset = 0
+    clock = 7372800
+    sample_rate = 'clkgen_x4'
+    mock_cwscope.adc.oa.hwInfo.maxSamples.return_value = -1
 
     with SScope(gain=gain,
                 samples=samples,


### PR DESCRIPTION
The SScope is expected to be initialized using capture_info (to have all
information present in capture_info). But capture_info might contain
more information which is not needed to initialize SScope. This commit
allows SScope to ignore the rest of the capture_info.