### PR TITLE
Make resume_kti more general

### DIFF
--- a/scaaml/capture/aes/aes_capture_contexts.py
+++ b/scaaml/capture/aes/aes_capture_contexts.py
@@ -179,9 +179,9 @@ def capture_aes_dataset(
             examples_per_shard=examples_per_shard,
             firmware_sha256=firmware_sha256,
             full_kt_filename=Path(root_path) / dataset.slug /
-            f"{split}_key_text_pairs.txt",
+            f"{split}_parameters_tuples.txt",
             full_progress_filename=Path(root_path) / dataset.slug /
-            f"{split}_progress_pairs.txt")
+            f"{split}_progress_tuples.txt")
         crypto_algorithms.append(new_crypto_alg)
 
     if test_keys:

--- a/scaaml/capture/aes/capture_runner.py
+++ b/scaaml/capture/aes/capture_runner.py
@@ -73,9 +73,9 @@ class CaptureRunner(AbstractCaptureRunner):
 
         return trace
 
-    def get_attack_points_and_measurement(
-            self, crypto_alg: AbstractSCryptoAlgorithm,
-            crypto_input: CryptoInput) -> Tuple[Dict, Dict]:
+    def get_attack_points_and_measurement(self,
+                                          crypto_alg: AbstractSCryptoAlgorithm,
+                                          crypto_input) -> Tuple[Dict, Dict]:
         """Get attack points and measurement. Repeat capture if necessary.
         Raises if hardware fails.
 

--- a/scaaml/capture/aes/capture_runner.py
+++ b/scaaml/capture/aes/capture_runner.py
@@ -73,16 +73,17 @@ class CaptureRunner(AbstractCaptureRunner):
 
         return trace
 
-    def get_attack_points_and_measurement(self,
-                                          crypto_alg: AbstractSCryptoAlgorithm,
-                                          crypto_input) -> Tuple[Dict, Dict]:
+    def get_attack_points_and_measurement(
+            self, crypto_alg: AbstractSCryptoAlgorithm,
+            crypto_input: CryptoInput) -> Tuple[Dict, Dict]:
         """Get attack points and measurement. Repeat capture if necessary.
         Raises if hardware fails.
 
         Args:
-          crypto_alg: The object used to get attack points.
-          crypto_input: Representation of the input of the cryptographic
-            algorithm.
+          crypto_alg (AbstractSCryptoAlgorithm): The object used to get
+            attack points.
+          crypto_input (CryptoInput): Representation of the input of the
+            cryptographic algorithm.
 
         Returns: Attack points and physical measurement. These are to be used
           directly by scaaml.io.Dataset.write_example. Returns a pair of

--- a/scaaml/capture/aes/capture_runner.py
+++ b/scaaml/capture/aes/capture_runner.py
@@ -30,7 +30,7 @@ class CaptureRunner(AbstractCaptureRunner):
 
         Args:
           kt_element: Single element received from looping over ResumeKTI
-            instance. A pair of np arrays.
+            instance. A dictionary of np arrays.
 
         Returns: An instance of input of cryptographic algorithm (an object
           holding a key and plaintext).

--- a/scaaml/capture/aes/crypto_alg.py
+++ b/scaaml/capture/aes/crypto_alg.py
@@ -81,8 +81,10 @@ class SCryptoAlgorithm(AbstractSCryptoAlgorithm):
             texts.append(list(text))
         # Does not overwrite existing keys-texts file.
         self._kti = resume_kti.create_resume_kti(
-            keys=np.array(keys_list, dtype=np.uint8),
-            texts=np.array(texts, dtype=np.uint8),
+            parameters={
+                "keys": np.array(keys_list, dtype=np.uint8),
+                "texts": np.array(texts, dtype=np.uint8),
+            },
             shard_length=np.uint64(self._examples_per_shard),
             kt_filename=self._full_kt_filename,
             progress_filename=self._full_progress_filename)
@@ -119,7 +121,7 @@ class SCryptoAlgorithm(AbstractSCryptoAlgorithm):
                 # AcqKeyTextPatternScaaml.new_pair raises StopIteration itself.
                 kt_pair = self._ktp.new_pair()
                 # Allow the same iteration as using resume_kti.
-                return list(kt_pair[0]), list(kt_pair[1])
+                return {"keys": list(kt_pair[0]), "texts": list(kt_pair[1])}
 
         self._stabilization_ktp = StabilizationIterator(self._get_new_ktp())
         return self._stabilization_ktp

--- a/scaaml/capture/aes/crypto_alg.py
+++ b/scaaml/capture/aes/crypto_alg.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """AES specific SCryptoAlgorithm."""
+from collections import namedtuple
 from typing import Iterator, Optional
 import numpy as np
 
@@ -113,6 +114,8 @@ class SCryptoAlgorithm(AbstractSCryptoAlgorithm):
 
             def __init__(self, ktp):
                 self._ktp = ktp
+                self._element_class = namedtuple("EncryptionParameters",
+                                                 ["keys", "texts"])
 
             def __iter__(self):
                 return self
@@ -121,7 +124,8 @@ class SCryptoAlgorithm(AbstractSCryptoAlgorithm):
                 # AcqKeyTextPatternScaaml.new_pair raises StopIteration itself.
                 kt_pair = self._ktp.new_pair()
                 # Allow the same iteration as using resume_kti.
-                return {"keys": list(kt_pair[0]), "texts": list(kt_pair[1])}
+                return self._element_class(keys=list(kt_pair[0]),
+                                           texts=list(kt_pair[1]))
 
         self._stabilization_ktp = StabilizationIterator(self._get_new_ktp())
         return self._stabilization_ktp

--- a/scaaml/capture/aes/crypto_alg.py
+++ b/scaaml/capture/aes/crypto_alg.py
@@ -35,8 +35,8 @@ class SCryptoAlgorithm(AbstractSCryptoAlgorithm):
                  plaintexts: int = 256,
                  repetitions: int = 1,
                  examples_per_shard: int = 64,
-                 full_kt_filename: str = "key_text_pairs.txt",
-                 full_progress_filename: str = "progress_pairs.txt") -> None:
+                 full_kt_filename: str = "parameters_tuples.txt",
+                 full_progress_filename: str = "progress_tuples.txt") -> None:
         """Generates a set of key-text pairs and saves those. Does not overwrite
         existing files.
 

--- a/scaaml/capture/aes/crypto_input.py
+++ b/scaaml/capture/aes/crypto_input.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 """The class that represents input of the AES cryptographic algorithm."""
 
-from collections import namedtuple
-from typing import Dict, NamedTuple
+from typing import Dict
 
 from scaaml.capture.crypto_input import AbstractCryptoInput
 
@@ -22,7 +21,7 @@ from scaaml.capture.crypto_input import AbstractCryptoInput
 class CryptoInput(AbstractCryptoInput):
     """Single instance of cryptographic input for AES."""
 
-    def __init__(self, kt_element: NamedTuple) -> None:
+    def __init__(self, kt_element) -> None:
         """Initialize the crypto input.
 
         Args:

--- a/scaaml/capture/aes/crypto_input.py
+++ b/scaaml/capture/aes/crypto_input.py
@@ -32,7 +32,7 @@ class CryptoInput(AbstractCryptoInput):
            from scaaml.aes_forward import AES
 
            crypto_input = CryptoInput(key=key, plaintext=plaintext)
-           ap_name = 'sub_bytes_in'
+           ap_name = "sub_bytes_in"
            sub_bytes_in = AES.get_attack_point(name=ap_name,
                                                **crypto_input.kwargs())
         """
@@ -51,18 +51,18 @@ class CryptoInput(AbstractCryptoInput):
            from scaaml.aes_forward import AES
 
            crypto_input = CryptoInput(key=key, plaintext=plaintext)
-           ap_name = 'sub_bytes_in'
+           ap_name = "sub_bytes_in"
            sub_bytes_in = AES.get_attack_point(name=ap_name,
                                                **crypto_input.kwargs())
         """
         return {
-            'key': self._key,
-            'plaintext': self._plaintext,
+            "key": self._key,
+            "plaintext": self._plaintext,
         }
 
     def __str__(self) -> str:
         """String representation for debugging purposes."""
-        return f'key: {self._key} plaintext: {self._plaintext}'
+        return f"key: {self._key} plaintext: {self._plaintext}"
 
     @property
     def key(self) -> bytearray:

--- a/scaaml/capture/aes/crypto_input.py
+++ b/scaaml/capture/aes/crypto_input.py
@@ -25,8 +25,8 @@ class CryptoInput(AbstractCryptoInput):
         """Initialize the crypto input.
 
         Args:
-          kt_element: An element returned by iteration over ResumeKTI (key,
-            plaintext pair of np.arrays).
+          kt_element: An element returned by iteration over ResumeKTI
+            (dictionary of np.arrays with key, plaintext).
 
         Example use:
            from scaaml.aes_forward import AES
@@ -37,9 +37,8 @@ class CryptoInput(AbstractCryptoInput):
                                                **crypto_input.kwargs())
         """
         super().__init__()
-        key, text = kt_element
-        self._key = bytearray(key)
-        self._plaintext = bytearray(text)
+        self._key = bytearray(kt_element["keys"])
+        self._plaintext = bytearray(kt_element["texts"])
 
     def key_for_new_shard(self) -> bytearray:
         """Return the key parameter of scaaml.io.Dataset.new_shard."""

--- a/scaaml/capture/aes/crypto_input.py
+++ b/scaaml/capture/aes/crypto_input.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 """The class that represents input of the AES cryptographic algorithm."""
 
-from typing import Dict
+from collections import namedtuple
+from typing import Dict, NamedTuple
 
 from scaaml.capture.crypto_input import AbstractCryptoInput
 
@@ -21,24 +22,24 @@ from scaaml.capture.crypto_input import AbstractCryptoInput
 class CryptoInput(AbstractCryptoInput):
     """Single instance of cryptographic input for AES."""
 
-    def __init__(self, kt_element) -> None:
+    def __init__(self, kt_element: NamedTuple) -> None:
         """Initialize the crypto input.
 
         Args:
-          kt_element: An element returned by iteration over ResumeKTI
-            (dictionary of np.arrays with key, plaintext).
+          kt_element (namedtuple): An element returned by iteration over
+            ResumeKTI (namedtuple of np.arrays with key, plaintext).
 
         Example use:
            from scaaml.aes_forward import AES
 
-           crypto_input = CryptoInput(key=key, plaintext=plaintext)
+           crypto_input = CryptoInput(kt_element)
            ap_name = "sub_bytes_in"
            sub_bytes_in = AES.get_attack_point(name=ap_name,
                                                **crypto_input.kwargs())
         """
         super().__init__()
-        self._key = bytearray(kt_element["keys"])
-        self._plaintext = bytearray(kt_element["texts"])
+        self._key = bytearray(kt_element.keys)
+        self._plaintext = bytearray(kt_element.texts)
 
     def key_for_new_shard(self) -> bytearray:
         """Return the key parameter of scaaml.io.Dataset.new_shard."""
@@ -50,7 +51,7 @@ class CryptoInput(AbstractCryptoInput):
         Example use:
            from scaaml.aes_forward import AES
 
-           crypto_input = CryptoInput(key=key, plaintext=plaintext)
+           crypto_input = CryptoInput(kt_element)
            ap_name = "sub_bytes_in"
            sub_bytes_in = AES.get_attack_point(name=ap_name,
                                                **crypto_input.kwargs())

--- a/scaaml/capture/capture_runner.py
+++ b/scaaml/capture/capture_runner.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """CaptureRunner runs the capture."""
 from abc import ABC, abstractmethod
-from collections import namedtuple
 from typing import Dict, List, NamedTuple, Tuple
 from tqdm.auto import tqdm
 

--- a/scaaml/capture/capture_runner.py
+++ b/scaaml/capture/capture_runner.py
@@ -65,7 +65,7 @@ class AbstractCaptureRunner(ABC):
 
         Args:
           kt_element: Single element received from looping over ResumeKTI
-            instance. A pair of np arrays.
+            instance. A dictionary of np arrays.
 
         Returns: An instance of input for cryptographic algorithm (for example
           an object holding a key and plaintext).
@@ -80,7 +80,7 @@ class AbstractCaptureRunner(ABC):
 
         Args:
           crypto_alg: The object used to get attack points.
-          crypto_input: The input from ResumeKTI (a pair of np arrays).
+          crypto_input: The input from ResumeKTI (a dictionary of np arrays).
 
         Returns: Attack points and physical measurement. These are to be used
           directly by scaaml.io.Dataset.write_example.

--- a/scaaml/capture/capture_runner.py
+++ b/scaaml/capture/capture_runner.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 """CaptureRunner runs the capture."""
 from abc import ABC, abstractmethod
-from typing import Dict, List, Tuple
+from collections import namedtuple
+from typing import Dict, List, NamedTuple, Tuple
 from tqdm.auto import tqdm
 
 from scaaml.io import Dataset
@@ -59,28 +60,29 @@ class AbstractCaptureRunner(ABC):
         self._dataset = dataset
 
     @abstractmethod
-    def get_crypto_input(self, kt_element) -> AbstractCryptoInput:
+    def get_crypto_input(self, kt_element: NamedTuple) -> AbstractCryptoInput:
         """Process single element from ResumeKTI and return information for
         the crypto algorithm.
 
         Args:
-          kt_element: Single element received from looping over ResumeKTI
-            instance. A dictionary of np arrays.
+          kt_element (namedtuple): Single element received from looping over
+            ResumeKTI instance. A namedtuple of np arrays.
 
         Returns: An instance of input for cryptographic algorithm (for example
           an object holding a key and plaintext).
         """
 
     @abstractmethod
-    def get_attack_points_and_measurement(self,
-                                          crypto_alg: AbstractSCryptoAlgorithm,
-                                          crypto_input) -> Tuple[Dict, Dict]:
+    def get_attack_points_and_measurement(
+            self, crypto_alg: AbstractSCryptoAlgorithm,
+            crypto_input: AbstractCryptoInput) -> Tuple[Dict, Dict]:
         """Get attack points and measurement. Repeat capture if necessary.
         Raises if hardware fails.
 
         Args:
-          crypto_alg: The object used to get attack points.
-          crypto_input: The input from ResumeKTI (a dictionary of np arrays).
+          crypto_alg (AbstractSCryptoAlgorithm): The object used to get attack
+            points.
+          crypto_input (AbstractCryptoInput): The input for encryption.
 
         Returns: Attack points and physical measurement. These are to be used
           directly by scaaml.io.Dataset.write_example.

--- a/scaaml/capture/crypto_alg.py
+++ b/scaaml/capture/crypto_alg.py
@@ -32,8 +32,8 @@ class AbstractSCryptoAlgorithm(ABC):
                  plaintexts: int,
                  repetitions: int,
                  examples_per_shard: int,
-                 full_kt_filename: str = "key_text_pairs.txt",
-                 full_progress_filename: str = "progress_pairs.txt") -> None:
+                 full_kt_filename: str = "parameters_tuples.txt",
+                 full_progress_filename: str = "progress_tuples.txt") -> None:
         """Generates a set of key-text pairs and saves those. Does not overwrite
         existing files.
 

--- a/scaaml/io/resume_kti.py
+++ b/scaaml/io/resume_kti.py
@@ -185,12 +185,10 @@ class ResumeKTI:
             # Load list of parameter names.
             parameter_names = np.load(kt_tuples, allow_pickle=allow_pickle)
             # Create the namedtuple class. Ignore mypy warning that named
-            # tuples should not be constructed dynamically. Moreover mypy is
-            # able to ignore a single line and linting causes multi-line, thus
-            # temporary variable.
-            element_class = namedtuple("EncryptionParameters",
-                                       list(parameter_names))
-            self._element_class = element_class  # type: ignore
+            # tuples should not be constructed dynamically and that a list or
+            # tuple literal should be used for the names.
+            self._element_class = namedtuple(  # type: ignore
+                "EncryptionParameters", parameter_names)
 
             # Load all parameters.
             self._parameters = {}

--- a/scaaml/io/resume_kti.py
+++ b/scaaml/io/resume_kti.py
@@ -59,7 +59,7 @@ File format:
 """
 
 from collections import namedtuple
-from typing import Dict, List, NamedTuple
+from typing import Dict, List
 
 import numpy as np
 
@@ -184,9 +184,11 @@ class ResumeKTI:
 
             # Load list of parameter names.
             parameter_names = np.load(kt_tuples, allow_pickle=allow_pickle)
-            # Create the namedtuple class.
-            self._element_class = namedtuple("EncryptionParameters",
-                                             parameter_names)
+            # Create the namedtuple class. Ignore mypy warning that namedtuples
+            # should not be constructed dynamically.
+            self._element_class = namedtuple(
+                "EncryptionParameters",
+                parameter_names.tolist())  # type: ignore
 
             # Load all parameters.
             self._parameters = {}
@@ -229,7 +231,7 @@ class ResumeKTI:
     def __iter__(self):
         return self
 
-    def __next__(self) -> NamedTuple:
+    def __next__(self):
         """Next with auto-save.
 
         Auto-save when a new shard is starting (after each shard length + 1

--- a/scaaml/io/resume_kti.py
+++ b/scaaml/io/resume_kti.py
@@ -22,13 +22,13 @@ Typical usage example:
   # If kt_filename exists this does nothing.
   create_resume_kti(parameters={"keys": keys, "texts": texts},
                     shard_length=shard_length,
-                    kt_filename="key_text_pairs.txt",
-                    progress_filename="progress_pairs.txt")
+                    kt_filename="parameters_tuples.txt",
+                    progress_filename="progress_tuples.txt")
 
   # Load the savepoint (all the pairs + the index where to continue) at the
   # start or resume of the experiment.
-  resume_kti = ResumeKTI(kt_filename="key_text_pairs.txt",
-                         progress_filename="progress_pairs.txt"
+  resume_kti = ResumeKTI(kt_filename="parameters_tuples.txt",
+                         progress_filename="progress_tuples.txt"
 
   # for key, text in tqdm(resume_kti):  # Loop with a progress-bar.
   for current_parameters in resume_kti:
@@ -87,8 +87,8 @@ def check_lengths(parameters: Dict[str, np.ndarray],
         plaintexts, masks...). A dictionary with name and the corresponding
         parameters represented as an np.array. All values must have the same
         non-zero length, their length must be a multiple of shard_length.
-      shard_length: How many pairs are in a shard. ResumeKTI autosaves
-        progress after finishing a shard.
+      shard_length (np.uint64): How many pairs are in a shard. ResumeKTI
+        autosaves progress after finishing a shard.
 
     Raises: ValueError if some length is not right.
     """
@@ -109,8 +109,8 @@ def check_lengths(parameters: Dict[str, np.ndarray],
 
 def _create_resume_kti(parameters: Dict[str, np.ndarray],
                        shard_length: np.uint64,
-                       kt_filename: str = "key_text_pairs.txt",
-                       progress_filename: str = "progress_pairs.txt",
+                       kt_filename: str = "parameters_tuples.txt",
+                       progress_filename: str = "progress_tuples.txt",
                        allow_pickle: bool = False) -> None:
     """Saves the key-text pairs for later use. See create_resume_kti convenience
     function.
@@ -120,8 +120,8 @@ def _create_resume_kti(parameters: Dict[str, np.ndarray],
           plaintexts, masks...). A dictionary with name and the corresponding
           parameters represented as an np.array. All values must have the same
           non-zero length, their length must be a multiple of shard_length.
-        shard_length: How many pairs are in a shard. ResumeKTI autosaves
-          progress after finishing a shard.
+        shard_length (np.uint64): How many pairs are in a shard. ResumeKTI
+          autosaves progress after finishing a shard.
         kt_filename: File where to save shard_length and parameters. If the
           file exists prints a message, but does not overwrite.
         progress_filename: The file with the number of traces captured so far.
@@ -165,8 +165,8 @@ class ResumeKTI:
     """
 
     def __init__(self,
-                 kt_filename: str = "key_text_pairs.txt",
-                 progress_filename: str = "progress_pairs.txt",
+                 kt_filename: str = "parameters_tuples.txt",
+                 progress_filename: str = "progress_tuples.txt",
                  allow_pickle: bool = False) -> None:
         """Create a resumable key-text iterable.
 
@@ -264,8 +264,8 @@ class ResumeKTI:
 
 def create_resume_kti(parameters: Dict[str, np.ndarray],
                       shard_length: np.uint64,
-                      kt_filename: str = "key_text_pairs.txt",
-                      progress_filename: str = "progress_pairs.txt",
+                      kt_filename: str = "parameters_tuples.txt",
+                      progress_filename: str = "progress_tuples.txt",
                       allow_pickle: bool = False) -> ResumeKTI:
     """Saves the key-text pairs and returns a ResumeKTI object for immediate
     use.
@@ -275,8 +275,8 @@ def create_resume_kti(parameters: Dict[str, np.ndarray],
           plaintexts, masks...). A dictionary with name and the corresponding
           parameters represented as an np.array. All values must have the same
           non-zero length, their length must be a multiple of shard_length.
-        shard_length: How many pairs are in a shard. ResumeKTI autosaves
-          progress after finishing a shard.
+        shard_length (np.uint64): How many pairs are in a shard. ResumeKTI
+          autosaves progress after finishing a shard.
         kt_filename: File where to save shard_length and parameters. If the
           file exists prints a message, but does not overwrite.
         progress_filename: The file with the number of traces captured so far.

--- a/scaaml/io/resume_kti.py
+++ b/scaaml/io/resume_kti.py
@@ -18,14 +18,14 @@ Autosaves after shard length iterations.
 
 Typical usage example:
 
-  # Save all key-text pairs ahead before the experiment starts.
+  # Save all encryption parameter tuples ahead before the experiment starts.
   # If kt_filename exists this does nothing.
   create_resume_kti(parameters={"keys": keys, "texts": texts},
                     shard_length=shard_length,
                     kt_filename="parameters_tuples.txt",
                     progress_filename="progress_tuples.txt")
 
-  # Load the savepoint (all the pairs + the index where to continue) at the
+  # Load the savepoint (all the tuples + the index where to continue) at the
   # start or resume of the experiment.
   resume_kti = ResumeKTI(kt_filename="parameters_tuples.txt",
                          progress_filename="progress_tuples.txt"
@@ -44,7 +44,7 @@ Typical usage example:
 
 File format:
 
-  Text-key pairs file is a binary file with numpy scalar and arrays. The
+  Parameter tuples file is a binary file with numpy scalar and arrays. The
   contents are shard length, array of strings with parameter names and then
   arrays of parameters in the same order. The array of parameter values are
   interpreted in the way that (parameter1[i], parameter2[i], ...) is a single
@@ -88,7 +88,7 @@ def check_lengths(parameters: Dict[str, np.ndarray],
         plaintexts, masks...). A dictionary with name and the corresponding
         parameters represented as an np.array. All values must have the same
         non-zero length, their length must be a multiple of shard_length.
-      shard_length (np.uint64): How many pairs are in a shard. ResumeKTI
+      shard_length (np.uint64): How many tuples are in a shard. ResumeKTI
         autosaves progress after finishing a shard.
 
     Raises: ValueError if some length is not right.
@@ -113,15 +113,15 @@ def _create_resume_kti(parameters: Dict[str, np.ndarray],
                        kt_filename: str = "parameters_tuples.txt",
                        progress_filename: str = "progress_tuples.txt",
                        allow_pickle: bool = False) -> None:
-    """Saves the key-text pairs for later use. See create_resume_kti convenience
-    function.
+    """Saves the parameter tuples for later use. See create_resume_kti
+    convenience function.
 
     Args:
         parameters (Dict[str, np.ndarray]): Parameters of the encryption (keys,
           plaintexts, masks...). A dictionary with name and the corresponding
           parameters represented as an np.array. All values must have the same
           non-zero length, their length must be a multiple of shard_length.
-        shard_length (np.uint64): How many pairs are in a shard. ResumeKTI
+        shard_length (np.uint64): How many tuples are in a shard. ResumeKTI
           autosaves progress after finishing a shard.
         kt_filename: File where to save shard_length and parameters. If the
           file exists prints a message, but does not overwrite.
@@ -178,12 +178,12 @@ class ResumeKTI:
               calling _save_progress.
             allow_pickle: Parameter for numpy.load.
         """
-        with open(kt_filename, "rb") as kt_pairs:
+        with open(kt_filename, "rb") as kt_tuples:
             # Load shard length.
-            self._shard_length = np.load(kt_pairs, allow_pickle=allow_pickle)
+            self._shard_length = np.load(kt_tuples, allow_pickle=allow_pickle)
 
             # Load list of parameter names.
-            parameter_names = np.load(kt_pairs, allow_pickle=allow_pickle)
+            parameter_names = np.load(kt_tuples, allow_pickle=allow_pickle)
             # Create the namedtuple class.
             self._element_class = namedtuple("EncryptionParameters",
                                              parameter_names)
@@ -192,7 +192,7 @@ class ResumeKTI:
             self._parameters = {}
             for parameter_name in parameter_names:
                 self._parameters[parameter_name] = np.load(
-                    kt_pairs, allow_pickle=allow_pickle)
+                    kt_tuples, allow_pickle=allow_pickle)
 
         # Check length of parameters.
         check_lengths(parameters=self._parameters,
@@ -251,8 +251,8 @@ class ResumeKTI:
             })
 
     def __len__(self) -> int:
-        """How many pairs are there in total (including the initial_index
-        skipped pairs)."""
+        """How many tuples are there in total (including the initial_index
+        skipped tuples)."""
         return get_any_value_len(self._parameters)
 
     @property
@@ -272,7 +272,7 @@ def create_resume_kti(parameters: Dict[str, np.ndarray],
                       kt_filename: str = "parameters_tuples.txt",
                       progress_filename: str = "progress_tuples.txt",
                       allow_pickle: bool = False) -> ResumeKTI:
-    """Saves the key-text pairs and returns a ResumeKTI object for immediate
+    """Saves the parameter tuples and returns a ResumeKTI object for immediate
     use.
 
     Args:
@@ -280,7 +280,7 @@ def create_resume_kti(parameters: Dict[str, np.ndarray],
           plaintexts, masks...). A dictionary with name and the corresponding
           parameters represented as an np.array. All values must have the same
           non-zero length, their length must be a multiple of shard_length.
-        shard_length (np.uint64): How many pairs are in a shard. ResumeKTI
+        shard_length (np.uint64): How many tuples are in a shard. ResumeKTI
           autosaves progress after finishing a shard.
         kt_filename: File where to save shard_length and parameters. If the
           file exists prints a message, but does not overwrite.

--- a/scaaml/io/resume_kti.py
+++ b/scaaml/io/resume_kti.py
@@ -185,10 +185,12 @@ class ResumeKTI:
             # Load list of parameter names.
             parameter_names = np.load(kt_tuples, allow_pickle=allow_pickle)
             # Create the namedtuple class. Ignore mypy warning that named
-            # tuples should not be constructed dynamically.
-            self._element_class = namedtuple(
-                "EncryptionParameters",
-                parameter_names.tolist())  # type: ignore
+            # tuples should not be constructed dynamically. Moreover mypy is
+            # able to ignore a single line and linting causes multi-line, thus
+            # temporary variable.
+            element_class = namedtuple("EncryptionParameters",
+                                       list(parameter_names))
+            self._element_class = element_class  # type: ignore
 
             # Load all parameters.
             self._parameters = {}

--- a/scaaml/io/resume_kti.py
+++ b/scaaml/io/resume_kti.py
@@ -248,8 +248,8 @@ class ResumeKTI:
 
         # Construct the namedtuple to return.
         element_class_parameters = {
-            parameter_name: self._parameters[parameter_name][self._index - 1]
-            for parameter_name in self._parameters  # pylint: disable=C0206
+            parameter_name: parameter_values[self._index - 1]
+            for parameter_name, parameter_values in self._parameters.items()
         }
         return self._element_class(**element_class_parameters)
 

--- a/scaaml/io/resume_kti.py
+++ b/scaaml/io/resume_kti.py
@@ -247,12 +247,13 @@ class ResumeKTI:
         if self._index >= get_any_value_len(self._parameters):
             raise StopIteration
         self._index += 1
-        return self._element_class(
-            **{
-                parameter_name: self._parameters[parameter_name][self._index -
-                                                                 1]
-                for parameter_name in self._parameters  # pylint: disable=C0206
-            })
+
+        # Construct the namedtuple to return.
+        element_class_parameters = {
+            parameter_name: self._parameters[parameter_name][self._index - 1]
+            for parameter_name in self._parameters  # pylint: disable=C0206
+        }
+        return self._element_class(**element_class_parameters)
 
     def __len__(self) -> int:
         """How many tuples are there in total (including the initial_index

--- a/scaaml/io/resume_kti.py
+++ b/scaaml/io/resume_kti.py
@@ -184,8 +184,8 @@ class ResumeKTI:
 
             # Load list of parameter names.
             parameter_names = np.load(kt_tuples, allow_pickle=allow_pickle)
-            # Create the namedtuple class. Ignore mypy warning that namedtuples
-            # should not be constructed dynamically.
+            # Create the namedtuple class. Ignore mypy warning that named
+            # tuples should not be constructed dynamically.
             self._element_class = namedtuple(
                 "EncryptionParameters",
                 parameter_names.tolist())  # type: ignore

--- a/tests/capture/aes/test_capture_runner.py
+++ b/tests/capture/aes/test_capture_runner.py
@@ -80,7 +80,10 @@ def test_stabilize_capture(mock_capture_trace):
     m_crypto_alg = MagicMock()
     k = MagicMock()
     t = MagicMock()
-    m_crypto_alg.get_stabilization_kti.return_value = iter(({"keys": k, "texts": t},))
+    m_crypto_alg.get_stabilization_kti.return_value = iter(({
+        "keys": k,
+        "texts": t,
+    },))
     m_scope = MagicMock()
     m_communication = MagicMock()
     m_control = MagicMock()

--- a/tests/capture/aes/test_capture_runner.py
+++ b/tests/capture/aes/test_capture_runner.py
@@ -38,7 +38,7 @@ def test_capture_trace(mock_capture_trace):
     plaintext = np.array([255, 254, 0, 3, 4, 5, 6, 7, 8, 9, 15, 1, 2, 3, 1, 5],
                          dtype=np.uint8)
     mock_capture_trace.return_value.textin = bytearray(plaintext)
-    crypto_input = CryptoInput((key, plaintext))
+    crypto_input = CryptoInput({"keys": key, "texts": plaintext})
     capture_runner.capture_trace(crypto_input=crypto_input)
     mock_capture_trace.assert_called_once_with(scope=m_scope.scope,
                                                target=m_communication.target,
@@ -50,7 +50,7 @@ def test_capture_trace(mock_capture_trace):
 def test_get_attack_points_and_measurement(mock_capture_trace):
     key = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
     plaintext = [255, 254, 0, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
-    crypto_input = CryptoInput((key, plaintext))
+    crypto_input = CryptoInput({"keys": key, "texts": plaintext})
     trace = MagicMock()
     trace.textin = bytearray(plaintext)
     mock_capture_trace.side_effect = [None, False, trace]
@@ -80,7 +80,7 @@ def test_stabilize_capture(mock_capture_trace):
     m_crypto_alg = MagicMock()
     k = MagicMock()
     t = MagicMock()
-    m_crypto_alg.get_stabilization_kti.return_value = iter(((k, t),))
+    m_crypto_alg.get_stabilization_kti.return_value = iter(({"keys": k, "texts": t},))
     m_scope = MagicMock()
     m_communication = MagicMock()
     m_control = MagicMock()
@@ -125,8 +125,10 @@ def test_capture_dataset(mock_am):
     m_crypto_alg.examples_per_shard = examples_per_shard
     m_crypto_alg.plaintexts = plaintexts
     m_crypto_alg.repetitions = repetitions
-    m_crypto_alg.kti.__iter__ = lambda _: iter(
-        [(x % 256, x % 256) for x in range(keys * plaintexts * repetitions)])
+    m_crypto_alg.kti.__iter__ = lambda _: iter([{
+        "keys": x % 256,
+        "texts": x % 256,
+    } for x in range(keys * plaintexts * repetitions)])
     m_crypto_alg.kti.__len__ = lambda _: keys * plaintexts * repetitions
     m_crypto_alg.kti.initial_index = 0
 

--- a/tests/capture/aes/test_crypto_alg.py
+++ b/tests/capture/aes/test_crypto_alg.py
@@ -57,9 +57,9 @@ def test_init(mock_resumekti, mock_create_resume_kti):
     assert crypto_alg.key_len == 16
     stab_kti = crypto_alg.get_stabilization_kti()
     parameters = next(stab_kti)
-    assert crypto_alg.key_len == len(parameters["keys"])
+    assert crypto_alg.key_len == len(parameters.keys)
     assert crypto_alg.plaintext_len == 16
-    assert crypto_alg.plaintext_len == len(parameters["texts"])
+    assert crypto_alg.plaintext_len == len(parameters.texts)
     assert crypto_alg.firmware_sha256 == firmware_sha256
     assert crypto_alg.implementation == implementation
     assert crypto_alg.algorithm == algorithm

--- a/tests/capture/aes/test_crypto_alg.py
+++ b/tests/capture/aes/test_crypto_alg.py
@@ -56,10 +56,10 @@ def test_init(mock_resumekti, mock_create_resume_kti):
     assert crypto_alg.repetitions == repetitions
     assert crypto_alg.key_len == 16
     stab_kti = crypto_alg.get_stabilization_kti()
-    stab_k, stab_t = next(stab_kti)
-    assert crypto_alg.key_len == len(stab_k)
+    parameters = next(stab_kti)
+    assert crypto_alg.key_len == len(parameters["keys"])
     assert crypto_alg.plaintext_len == 16
-    assert crypto_alg.plaintext_len == len(stab_t)
+    assert crypto_alg.plaintext_len == len(parameters["texts"])
     assert crypto_alg.firmware_sha256 == firmware_sha256
     assert crypto_alg.implementation == implementation
     assert crypto_alg.algorithm == algorithm

--- a/tests/io/test_resume_kti.py
+++ b/tests/io/test_resume_kti.py
@@ -75,7 +75,7 @@ def test_save_and_load_k_t_m_different_len(tmp_path):
         "texts":
             TEXTS,
     }
-    with pytest.raises(AssertionError) as len_error:
+    with pytest.raises(ValueError) as len_error:
         save_and_load(parameters, tmp_path)
     assert "There are different number of parameter values." == str(
         len_error.value)

--- a/tests/io/test_resume_kti.py
+++ b/tests/io/test_resume_kti.py
@@ -38,7 +38,7 @@ def save_and_load(parameters, path):
     assert os.path.isfile(path / PROGRESS_FILENAME)
 
     # Check that the tuples have been loaded correctly
-    assert len(resume_kti) == len(next(iter(parameters.items())))
+    assert len(resume_kti) == len(next(iter(parameters.values())))
     i = 0
     for current_params in resume_kti:
         for name, value in current_params._asdict().values():
@@ -57,7 +57,7 @@ def test_save_and_load_k_t(tmp_path):
 def test_save_and_load_k_t_m(tmp_path):
     parameters = {
         "keys": KEYS,
-        "masks": np.random.randint(shape=KEYS.shape, dtype=np.uint8),
+        "masks": np.random.randint(50, size=KEYS.shape, dtype=np.uint8),
         "texts": TEXTS,
     }
     save_and_load(parameters, tmp_path)

--- a/tests/io/test_resume_kti.py
+++ b/tests/io/test_resume_kti.py
@@ -14,6 +14,7 @@
 
 import os
 import numpy as np
+import pytest
 
 from scaaml.io.resume_kti import create_resume_kti, ResumeKTI
 

--- a/tests/io/test_resume_kti.py
+++ b/tests/io/test_resume_kti.py
@@ -41,7 +41,7 @@ def save_and_load(parameters, path):
     assert len(resume_kti) == len(next(iter(parameters.values())))
     i = 0
     for current_params in resume_kti:
-        for name, value in current_params._asdict().values():
+        for name, value in current_params._asdict().items():
             assert value == parameters[name][i]
         i += 1
 
@@ -61,6 +61,18 @@ def test_save_and_load_k_t_m(tmp_path):
         "texts": TEXTS,
     }
     save_and_load(parameters, tmp_path)
+
+
+def test_save_and_load_k_t_m_different_len(tmp_path):
+    parameters = {
+        "keys": KEYS,
+        "masks": np.random.randint(50, size=KEYS.shape[0] + 1, dtype=np.uint8),
+        "texts": TEXTS,
+    }
+    with pytest.raises(AssertionError) as len_error:
+        save_and_load(parameters, tmp_path)
+    assert "There are different number of parameter values." == str(
+        len_error.value)
 
 
 def test_save_and_load_k(tmp_path):

--- a/tests/io/test_resume_kti.py
+++ b/tests/io/test_resume_kti.py
@@ -32,8 +32,7 @@ def save_and_load(parameters, path):
     resume_kti = create_resume_kti(parameters=parameters,
                                    shard_length=SHARD_LENGTH,
                                    kt_filename=path / KT_FILENAME,
-                                   progress_filename=path /
-                                   PROGRESS_FILENAME)
+                                   progress_filename=path / PROGRESS_FILENAME)
     # Check that the files exist now
     assert os.path.isfile(path / KT_FILENAME)
     assert os.path.isfile(path / PROGRESS_FILENAME)

--- a/tests/io/test_resume_kti.py
+++ b/tests/io/test_resume_kti.py
@@ -41,7 +41,7 @@ def save_and_load(parameters, path):
     assert len(resume_kti) == len(next(iter(parameters.items())))
     i = 0
     for current_params in resume_kti:
-        for name, value in current_params._asdict().items():
+        for name, value in current_params._asdict().values():
             assert value == parameters[name][i]
         i += 1
 
@@ -57,7 +57,7 @@ def test_save_and_load_k_t(tmp_path):
 def test_save_and_load_k_t_m(tmp_path):
     parameters = {
         "keys": KEYS,
-        "masks": np.random.randint(KEYS.shape, dtype=np.uint8),
+        "masks": np.random.randint(shape=KEYS.shape, dtype=np.uint8),
         "texts": TEXTS,
     }
     save_and_load(parameters, tmp_path)

--- a/tests/io/test_resume_kti.py
+++ b/tests/io/test_resume_kti.py
@@ -28,8 +28,8 @@ def test_save_and_load(tmp_path):
     # Check that the files do not exist now
     assert not os.path.isfile(tmp_path / KT_FILENAME)
     assert not os.path.isfile(tmp_path / PROGRESS_FILENAME)
-    resume_kti = create_resume_kti(keys=KEYS,
-                                   texts=TEXTS,
+    parameters = {"keys": KEYS, "texts": TEXTS}
+    resume_kti = create_resume_kti(parameters=parameters,
                                    shard_length=SHARD_LENGTH,
                                    kt_filename=tmp_path / KT_FILENAME,
                                    progress_filename=tmp_path /
@@ -41,9 +41,9 @@ def test_save_and_load(tmp_path):
     # Check that the (key, text) pairs have been loaded correctly
     assert len(resume_kti) == len(KEYS)
     i = 0
-    for k, t in resume_kti:
-        assert k == KEYS[i]
-        assert t == TEXTS[i]
+    for current_params in resume_kti:
+        for name, value in current_params.items():
+            assert value == parameters[name][i]
         i += 1
 
     # Check that the shard_length has been loaded correctly
@@ -52,8 +52,8 @@ def test_save_and_load(tmp_path):
 
 def iterate_for(tmp_path, n):
     # Iterates for n iterations, then resumes
-    resume_kti1 = create_resume_kti(keys=KEYS,
-                                    texts=TEXTS,
+    parameters = {"keys": KEYS, "texts": TEXTS}
+    resume_kti1 = create_resume_kti(parameters=parameters,
                                     shard_length=SHARD_LENGTH,
                                     kt_filename=tmp_path / KT_FILENAME,
                                     progress_filename=tmp_path /
@@ -63,9 +63,9 @@ def iterate_for(tmp_path, n):
 
     i = 0
     while i < n:
-        k, t = next(iter1)
-        assert k == KEYS[i]
-        assert t == TEXTS[i]
+        current_params = next(iter1)
+        for name, value in current_params.items():
+            assert value == parameters[name][i]
         i += 1
 
     # Iterate through the rest of shards
@@ -80,9 +80,9 @@ def iterate_for(tmp_path, n):
     else:
         j = n - (n % SHARD_LENGTH)
     while j < len(KEYS):
-        k, t = next(iter2)
-        assert k == KEYS[j]
-        assert t == TEXTS[j]
+        current_params = next(iter2)
+        for name, value in current_params.items():
+            assert value == parameters[name][j]
         j += 1
 
 
@@ -95,16 +95,18 @@ def test_partial_iteration(tmp_path):
 
 def test_does_not_overwrite(tmp_path):
     # Create real saving points.
-    create_resume_kti(keys=KEYS,
-                      texts=TEXTS,
+    parameters = {"keys": KEYS, "texts": TEXTS}
+    create_resume_kti(parameters=parameters,
                       shard_length=SHARD_LENGTH,
                       kt_filename=tmp_path / KT_FILENAME,
                       progress_filename=tmp_path / PROGRESS_FILENAME)
     # Attempt to overwrite
     inc_keys = KEYS + 1
     inc_texts = TEXTS + 1
-    resume_kti = create_resume_kti(keys=inc_keys,
-                                   texts=inc_texts,
+    resume_kti = create_resume_kti(parameters={
+        "keys":inc_keys,
+        "texts": inc_texts
+    },
                                    shard_length=SHARD_LENGTH,
                                    kt_filename=tmp_path / KT_FILENAME,
                                    progress_filename=tmp_path /
@@ -113,9 +115,9 @@ def test_does_not_overwrite(tmp_path):
     # Check that the (key, text) pairs have been loaded correctly
     assert len(resume_kti) == len(KEYS)
     i = 0
-    for k, t in resume_kti:
-        assert k == KEYS[i]
-        assert t == TEXTS[i]
+    for current_params in resume_kti:
+        for name, value in current_params.items():
+            assert value == parameters[name][i]
         i += 1
 
     # Check that the shard_length has been loaded correctly

--- a/tests/io/test_resume_kti.py
+++ b/tests/io/test_resume_kti.py
@@ -26,17 +26,17 @@ SHARD_LENGTH = 2
 
 def save_and_load(parameters, path):
     # Check that the files do not exist now
-    assert not os.path.isfile(tmp_path / KT_FILENAME)
-    assert not os.path.isfile(tmp_path / PROGRESS_FILENAME)
+    assert not os.path.isfile(path / KT_FILENAME)
+    assert not os.path.isfile(path / PROGRESS_FILENAME)
 
     resume_kti = create_resume_kti(parameters=parameters,
                                    shard_length=SHARD_LENGTH,
-                                   kt_filename=tmp_path / KT_FILENAME,
-                                   progress_filename=tmp_path /
+                                   kt_filename=path / KT_FILENAME,
+                                   progress_filename=path /
                                    PROGRESS_FILENAME)
     # Check that the files exist now
-    assert os.path.isfile(tmp_path / KT_FILENAME)
-    assert os.path.isfile(tmp_path / PROGRESS_FILENAME)
+    assert os.path.isfile(path / KT_FILENAME)
+    assert os.path.isfile(path / PROGRESS_FILENAME)
 
     # Check that the tuples have been loaded correctly
     assert len(resume_kti) == len(next(iter(parameters.items())))
@@ -52,7 +52,7 @@ def save_and_load(parameters, path):
 
 def test_save_and_load_k_t(tmp_path):
     parameters = {"keys": KEYS, "texts": TEXTS}
-    save_and_load(parameters, path)
+    save_and_load(parameters, tmp_path)
 
 
 def test_save_and_load_k_t_m(tmp_path):
@@ -61,14 +61,14 @@ def test_save_and_load_k_t_m(tmp_path):
         "masks": np.random.randint(KEYS.shape, dtype=np.uint8),
         "texts": TEXTS,
     }
-    save_and_load(parameters, path)
+    save_and_load(parameters, tmp_path)
 
 
 def test_save_and_load_k(tmp_path):
     parameters = {
         "keys": KEYS,
     }
-    save_and_load(parameters, path)
+    save_and_load(parameters, tmp_path)
 
 
 def iterate_for(tmp_path, n):

--- a/tests/io/test_resume_kti.py
+++ b/tests/io/test_resume_kti.py
@@ -66,9 +66,14 @@ def test_save_and_load_k_t_m(tmp_path):
 
 def test_save_and_load_k_t_m_different_len(tmp_path):
     parameters = {
-        "keys": KEYS,
-        "masks": np.random.randint(50, size=KEYS.shape[0] + 1, dtype=np.uint8),
-        "texts": TEXTS,
+        "keys":
+            KEYS,
+        "masks":
+            np.random.randint(50,
+                              size=KEYS.shape[0] + SHARD_LENGTH,
+                              dtype=np.uint8),
+        "texts":
+            TEXTS,
     }
     with pytest.raises(AssertionError) as len_error:
         save_and_load(parameters, tmp_path)

--- a/tests/io/test_resume_kti.py
+++ b/tests/io/test_resume_kti.py
@@ -17,8 +17,8 @@ import numpy as np
 
 from scaaml.io.resume_kti import create_resume_kti, ResumeKTI
 
-KT_FILENAME = 'key_text_pairs.txt'
-PROGRESS_FILENAME = 'progress_pairs.txt'
+KT_FILENAME = 'parameters_tuples.txt'
+PROGRESS_FILENAME = 'progress_tuples.txt'
 KEYS = np.array([3, 1, 4, 1, 5, 9, 0, 254, 255, 0])
 TEXTS = np.array([2, 7, 1, 2, 8, 0, 255, 254, 1, 0])
 SHARD_LENGTH = 2

--- a/tests/io/test_resume_kti.py
+++ b/tests/io/test_resume_kti.py
@@ -104,7 +104,7 @@ def test_does_not_overwrite(tmp_path):
     inc_keys = KEYS + 1
     inc_texts = TEXTS + 1
     resume_kti = create_resume_kti(parameters={
-        "keys":inc_keys,
+        "keys": inc_keys,
         "texts": inc_texts
     },
                                    shard_length=SHARD_LENGTH,


### PR DESCRIPTION
Allow any set of parameters (key, plaintext, mask...) to be saved using
resume_kti.

Fixes #48