### PR TITLE
Add plaintexts among AES attack points

### DIFF
--- a/scaaml/aes_forward.py
+++ b/scaaml/aes_forward.py
@@ -64,7 +64,11 @@ class AESSBOX:
         "key": {
             "len": 16,
             "max_val": _MAX_VAL,
-        }
+        },
+        "plaintext": {
+            "len": 16,
+            "max_val": _MAX_VAL,
+        },
     }
 
     @staticmethod
@@ -84,6 +88,12 @@ class AESSBOX:
         """Return what goes out of the SBOX."""
         assert len(key) == len(plaintext)
         return bytearray(AESSBOX._SB[x ^ y] for (x, y) in zip(key, plaintext))
+
+    @staticmethod
+    def plaintext(key: bytearray, plaintext: bytearray) -> bytearray:
+        """Return the plaintext. Useful for getting all attack points."""
+        assert len(key) == len(plaintext)
+        return plaintext
 
     @classmethod
     def get_attack_point(cls, name: str, **kwargs: bytearray) -> bytearray:

--- a/tests/capture/aes/test_crypto_alg.py
+++ b/tests/capture/aes/test_crypto_alg.py
@@ -94,6 +94,7 @@ def test_attack_points(mock_resumekti, mock_create_resume_kti):
     plaintext = bytearray(
         [255, 254, 0, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
     ap = {
+        'plaintext': plaintext,
         'sub_bytes_in': AESSBOX.sub_bytes_in(key=key, plaintext=plaintext),
         'sub_bytes_out': AESSBOX.sub_bytes_out(key=key, plaintext=plaintext),
         'key': key,
@@ -138,6 +139,10 @@ def test_attack_points_info(mock_resumekti, mock_create_resume_kti):
         'key': {
             'len': 16,
             'max_val': max_val,
-        }
+        },
+        'plaintext': {
+            'len': 16,
+            'max_val': max_val,
+        },
     }
     assert crypto_alg.attack_points_info() == api

--- a/tests/test_aes_forward.py
+++ b/tests/test_aes_forward.py
@@ -138,3 +138,5 @@ def test_attack_points():
                                         key=key, plaintext=text)
     assert AESSBOX.get_attack_point('sub_bytes_out', key=key,
                                     plaintext=text) == sub_bytes_out
+    assert AESSBOX.get_attack_point('plaintext', key=key,
+                                    plaintext=text) == text


### PR DESCRIPTION
This allows to deduce key from plaintext and sub_bytes_in or
sub_bytes_out