### PR TITLE
Make mypy check types inside all functions

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -27,4 +27,4 @@ jobs:
         run: echo ::add-matcher::./.github/python_matcher.json
       - name: Running mypy
         run: |
-          mypy --no-color-output --install-types --non-interactive --ignore-missing-imports scaaml
+          mypy --check-untyped-defs --no-color-output --install-types --non-interactive --ignore-missing-imports scaaml


### PR DESCRIPTION
By default mypy does not check types in functions without type signature. Add a flag to allow type checking inside such functions. This also removes extraneous comments on PRs.