### PR TITLE
Fix np.float being deprecated

### DIFF
--- a/scaaml/io/dataset.py
+++ b/scaaml/io/dataset.py
@@ -1033,15 +1033,16 @@ class Dataset():
         find_misspellings(fixed_dict.keys())  # Check for misspellings of keys.
         # Fix type of keys_per_group
         fixed_dict["keys_per_group"] = {
-            split:
-            {int(group): n_examples for group, n_examples in keys_info.items()}
-            for split, keys_info in loaded_dict["keys_per_group"].items()
+            split: {
+                int(group): n_examples
+                for group, n_examples in keys_info.items()
+            } for split, keys_info in loaded_dict["keys_per_group"].items()
         }
         # Fix type of examples_per_group
         fixed_dict["examples_per_group"] = {
-            split:
-            {int(group): n_examples for group, n_examples in ex_info.items()}
-            for split, ex_info in loaded_dict["examples_per_group"].items()
+            split: {
+                int(group): n_examples for group, n_examples in ex_info.items()
+            } for split, ex_info in loaded_dict["examples_per_group"].items()
         }
         # Fix missing keys
         if "licence" not in fixed_dict:

--- a/scaaml/stats/print_stats.py
+++ b/scaaml/stats/print_stats.py
@@ -63,9 +63,8 @@ class PrintStats:
         self._attack_point_info = attack_points_info
         self._split_ap_counters = {
             split: {
-                ap_name: [
-                    APCounter(attack_point_info=ap_info),
-                ] for ap_name, ap_info in attack_points_info.items()
+                ap_name: [APCounter(attack_point_info=ap_info),]
+                for ap_name, ap_info in attack_points_info.items()
             } for split in Dataset.SPLITS
         }
 

--- a/tests/io/test_dataset.py
+++ b/tests/io/test_dataset.py
@@ -117,7 +117,7 @@ def test_mutable_defaults(tmp_path):
     path_a.mkdir(parents=True, exist_ok=True)
     ds1 = Dataset.get_dataset(**dataset_constructor_kwargs(root_path=path_a))
     key = np.random.randint(0, 255, 16)
-    trace1 = np.zeros(1024, dtype=np.float)
+    trace1 = np.zeros(1024, dtype=np.float64)
     trace1[2] = 0.8  # max_val is written before deleting ds
     trace1[1] = -0.3  # max_val is written before deleting ds
     chip_id = 1
@@ -674,7 +674,7 @@ def test_min_max_values_ok(tmp_path):
         assert min_value <= max_value
         ds = Dataset(**dataset_constructor_kwargs(root_path=root_path))
         mid_point = min_value + (max_value - min_value) / 2
-        trace = np.full(1024, mid_point, dtype=np.float)
+        trace = np.full(1024, mid_point, dtype=np.float64)
         trace[0] = min_value
         trace[1] = max_value
         key = np.zeros(16, dtype=np.uint8)
@@ -698,9 +698,9 @@ def test_resume_capture(tmp_path):
     ds = Dataset.get_dataset(**kwargs)
     key = np.random.randint(0, 255, 16)
     key2 = np.random.randint(0, 255, 16)
-    trace1 = np.zeros(1024, dtype=np.float)
+    trace1 = np.zeros(1024, dtype=np.float64)
     trace1[2] = 0.8  # max_val is written before deleting ds
-    trace2 = np.zeros(1024, dtype=np.float)
+    trace2 = np.zeros(1024, dtype=np.float64)
     chip_id = 1
     ds.new_shard(key=key,
                  part=0,

--- a/tests/io/test_end_to_end.py
+++ b/tests/io/test_end_to_end.py
@@ -89,17 +89,19 @@ def dataset_e2e(dtype, root_dir):
     rng = np.random.default_rng(13)  # Make tests deterministic
     all_examples = [{
         "measurement": {
-            measurement_name: rng.standard_normal(
-                size=(measurements_info[measurement_name]["len"],
-                     )).astype(np.float32 if dtype == "float32" else np.float16)
+            measurement_name:
+                rng.standard_normal(
+                    size=(measurements_info[measurement_name]["len"],)
+                ).astype(np.float32 if dtype == "float32" else np.float16)
             for measurement_name in measurements_info
         },
         "attack_points": {
-            attack_point_name: rng.integers(
-                low=0,
-                high=attack_points_info[attack_point_name]["max_val"],
-                size=(attack_points_info[attack_point_name]["len"],),
-            )
+            attack_point_name:
+                rng.integers(
+                    low=0,
+                    high=attack_points_info[attack_point_name]["max_val"],
+                    size=(attack_points_info[attack_point_name]["len"],),
+                )
             for attack_point_name in attack_points_info
         },
     }

--- a/tests/io/test_end_to_end_additional_attack_points.py
+++ b/tests/io/test_end_to_end_additional_attack_points.py
@@ -89,17 +89,19 @@ def dataset_e2e(dtype, root_dir, trace_start, trace_len):
     rng = np.random.default_rng(13)  # Make tests deterministic
     all_examples = [{
         "measurement": {
-            measurement_name: rng.standard_normal(
-                size=(measurements_info[measurement_name]["len"],
-                     )).astype(np.float32 if dtype == "float32" else np.float16)
+            measurement_name:
+                rng.standard_normal(
+                    size=(measurements_info[measurement_name]["len"],)
+                ).astype(np.float32 if dtype == "float32" else np.float16)
             for measurement_name in measurements_info
         },
         "attack_points": {
-            attack_point_name: rng.integers(
-                low=0,
-                high=attack_points_info[attack_point_name]["max_val"],
-                size=(attack_points_info[attack_point_name]["len"],),
-            )
+            attack_point_name:
+                rng.integers(
+                    low=0,
+                    high=attack_points_info[attack_point_name]["max_val"],
+                    size=(attack_points_info[attack_point_name]["len"],),
+                )
             for attack_point_name in attack_points_info
         },
     }

--- a/tests/io/test_end_to_end_as_tfdataset.py
+++ b/tests/io/test_end_to_end_as_tfdataset.py
@@ -89,17 +89,19 @@ def dataset_e2e(dtype, root_dir, trace_start, trace_len, shuffle: int = 100):
     rng = np.random.default_rng(13)  # Make tests deterministic
     all_examples = [{
         "measurement": {
-            measurement_name: rng.standard_normal(
-                size=(measurements_info[measurement_name]["len"],
-                     )).astype(np.float32 if dtype == "float32" else np.float16)
+            measurement_name:
+                rng.standard_normal(
+                    size=(measurements_info[measurement_name]["len"],)
+                ).astype(np.float32 if dtype == "float32" else np.float16)
             for measurement_name in measurements_info
         },
         "attack_points": {
-            attack_point_name: rng.integers(
-                low=0,
-                high=attack_points_info[attack_point_name]["max_val"],
-                size=(attack_points_info[attack_point_name]["len"],),
-            )
+            attack_point_name:
+                rng.integers(
+                    low=0,
+                    high=attack_points_info[attack_point_name]["max_val"],
+                    size=(attack_points_info[attack_point_name]["len"],),
+                )
             for attack_point_name in attack_points_info
         },
     }


### PR DESCRIPTION
The alias np.float is being deprecated in NumPy 1.20. One can use either float or np.floatN.