### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/scaaml/capture/scope/picoscope.py
+++ b/scaaml/capture/scope/picoscope.py
@@ -13,35 +13,21 @@
 # limitations under the License.
 """Context manager for the scope."""
 
-from typing import Optional
+from typing import Literal, Optional
 from typing_extensions import TypeAlias
-import sys
 
 from scaaml.capture.scope import AbstractSScope
 from scaaml.capture.scope.ps6424e import Pico6424E as PicoScope6424E
 
-# Prevent importing Literal with older versions.
-if sys.version_info >= (3, 8):
-    from typing import Literal
-
 
 class PicoScope(AbstractSScope):
     """Scope context manager."""
-
-    # Define PicoScope types, keep compatibility (Literal was introduced in
-    # Python3.8).
-    if sys.version_info >= (3, 8):
-        CHANNEL_T: TypeAlias = Literal["A", "B", "C", "D", "E", "F", "G", "H",
-                                       "PORT0", "PORT1"]
-        COUPLING_T: TypeAlias = Literal["AC", "DC", "DC50"]
-        ATTENUATION_T: TypeAlias = Literal["1:1", "1:10"]
-        BW_LIMIT_T: TypeAlias = Literal["PICO_BW_FULL", "PICO_BW_20MHZ",
-                                        "PICO_BW_200MHZ"]
-    else:
-        CHANNEL_T: TypeAlias = str
-        COUPLING_T: TypeAlias = str
-        ATTENUATION_T: TypeAlias = str
-        BW_LIMIT_T: TypeAlias = str
+    CHANNEL_T: TypeAlias = Literal["A", "B", "C", "D", "E", "F", "G", "H",
+                                   "PORT0", "PORT1"]
+    COUPLING_T: TypeAlias = Literal["AC", "DC", "DC50"]
+    ATTENUATION_T: TypeAlias = Literal["1:1", "1:10"]
+    BW_LIMIT_T: TypeAlias = Literal["PICO_BW_FULL", "PICO_BW_20MHZ",
+                                    "PICO_BW_200MHZ"]
 
     def __init__(self, samples: int, sample_rate: float, offset: int,
                  trace_channel: CHANNEL_T, trace_probe_range: float,

--- a/scaaml/io/dataset.py
+++ b/scaaml/io/dataset.py
@@ -19,10 +19,9 @@ import json
 import os
 from collections import defaultdict
 import shutil
-import sys
 from time import time
 from typing_extensions import TypeAlias
-from typing import Dict, List, Optional, Union, Set, Tuple
+from typing import Dict, List, Literal, Optional, Union, Set, Tuple
 from pathlib import Path
 import pprint
 
@@ -41,20 +40,11 @@ from scaaml.io.utils import dtype_name_to_dtype, dtype_dtype_to_name
 from scaaml.io.shard import Shard
 from scaaml.io.errors import DatasetExistsError
 
-# Prevent importing Literal with older versions.
-if sys.version_info >= (3, 8):
-    from typing import Literal
-
 
 class Dataset():
     """Dataset class."""
     # Valid split values (used also as directory names).
-    # Define split type, keep compatibility (Literal was introduced in
-    # Python3.8).
-    if sys.version_info >= (3, 8):
-        SPLIT_T: TypeAlias = Literal["train", "test", "holdout"]
-    else:
-        SPLIT_T: TypeAlias = str
+    SPLIT_T: TypeAlias = Literal["train", "test", "holdout"]
     TRAIN_SPLIT: SPLIT_T = "train"
     TEST_SPLIT: SPLIT_T = "test"
     HOLDOUT_SPLIT: SPLIT_T = "holdout"

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ version = f"2.0.1r{int(time())}"
 
 setup(
     name="scaaml",
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     version=version,
     description="Side Channel Attack Assisted with Machine Learning",
     long_description=long_description,


### PR DESCRIPTION
So that we can use Literal when appropriate.