### PR TITLE
Cite the SCAAML paper using Github's citation files

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+preferred-citation:
+  type: article
+  authors:
+  - family-names: "Bursztein"
+    given-names: "Elie"
+  - family-names: "Invernizzi"
+    given-names: "Luca"
+  - family-names: "Král"
+    given-names: "Karel"
+  - family-names: "Moghimi"
+    given-names: "Daniel"
+  - family-names: "Picod"
+    given-names: "Jean-Michel"
+  - family-names: "Zhang"
+    given-names: "Marina"
+  doi: "10.48550/arXiv.2306.07249"
+  title: "Generic Attacks against Cryptographic Hardware through Long-Range Deep Learning"

--- a/README.md
+++ b/README.md
@@ -54,9 +54,17 @@ its codebase, models or datasets please cite:
 }
 ```
 
-Additionally please also cite the talks and publications that are the most relevant
-to your work, so reader can quickly find the right information. Last but not
-least, you are more than welcome to add your publication/talk to the list below by making a pull request 😊.
+To cite the [paper](https://arxiv.org/abs/2306.07249) describing the approach, please cite:
+```bibtex
+@misc{bursztein2023generic,
+      title={Generic Attacks against Cryptographic Hardware through Long-Range Deep Learning}, 
+      author={Elie Bursztein and Luca Invernizzi and Karel Král and Daniel Moghimi and Jean-Michel Picod and Marina Zhang},
+      year={2023},
+      eprint={2306.07249},
+      archivePrefix={arXiv},
+      primaryClass={cs.CR}
+}
+```
 
 ### SCAAML AES tutorial
 


### PR DESCRIPTION
(on Elie's request)

This change cites the latest SCAAML paper in the repository, so that's easily findable.
Additionally, it adds a [CITATION.cff](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files) file. Github adds a "Cite this repository" button on the repo page thanks to it.