### PR TITLE
Code coverage also on merge to main

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,6 +6,10 @@ on:
       - 'pytest.ini'
   pull_request:
     types: [opened, synchronize, reopened]
+  pull_request:
+    branches:
+      - main
+    types: [closed]
 jobs:
   unittesting:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
The code coverage should also run on merge to main since otherwise the banner is grey.

Issue #192