### PR TITLE
Bump action versions

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -10,9 +10,9 @@ jobs:
   mypy:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: 'pip'

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,13 +6,17 @@ on:
       - 'pytest.ini'
   pull_request:
     types: [opened, synchronize, reopened]
+  schedule:
+    - cron: 0 5 * * 1 # Every Monday at 5:00 UTC
+
 jobs:
   unittesting:
     runs-on: ubuntu-22.04
+    if: github.event_name != 'schedule'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: 'pip'
@@ -36,9 +40,9 @@ jobs:
   coverage:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: 'pip'
@@ -66,3 +70,4 @@ jobs:
         run: coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # We need all history to list all changed files.
           fetch-depth: 0
       - name: Set up node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "21"
       - name: Install cspell

--- a/.github/workflows/yapf.yml
+++ b/.github/workflows/yapf.yml
@@ -9,9 +9,9 @@ jobs:
   yapf:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: 'pip'


### PR DESCRIPTION
This removes the warnings about Node.js 16 being used.

Also put a scheduled run of the code coverage reports to ensure the badge always work.