### PR TITLE
Move from coveralls-python to Github action

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -61,13 +61,15 @@ jobs:
         run:
           pip install --upgrade picosdk
       - name: Install workflow dependencies
-        run: pip install --upgrade pytest coverage coveralls
-      - name: Running unit tests
-        run: coverage run
+        run: pip install --upgrade pytest coverage
+      - name: Running unit tests with coverage
         env:
           DISABLE_AUTOGRAPH: 1
+        run: |
+          coverage run -m pytest
+          coverage xml
       - name: Upload results
-        run: coveralls --service=github
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: coverallsapp/github-action@v2
+        with:
+          file: coverage.xml
 


### PR DESCRIPTION
Last release of coveralls-python is from 2021.
Removing that dependency before things starts to break.

The Github action doesn't handle the python `.coverage` file format very well so we convert it to XML before.

I considered adding a problem matcher too but that requires a lot of work as:
  - Github limits the amount of problems that can reported per test
  - coverage output isn't really in a machine-friendly format
  - problems only apply to a single line, which wouldn't help correctly reporting the untested line
  - we would need to filter out files that are not part of the PR

Conclusion is: let's use coveralls web UI instead :)