### PR TITLE
Fix targeting a bit

### DIFF
--- a/papers/2024/GPAM/gpam_ecc_cm1.py
+++ b/papers/2024/GPAM/gpam_ecc_cm1.py
@@ -413,7 +413,7 @@ def create_heads_outputs(x: Tensor, outputs: Dict[str, Dict],
         relations = ingoing_relations.get(name, [])
 
         # Get parameters for head creation.
-        dim = outputs[name]['max_val']
+        dim = outputs[name]['max_val'] if outputs[name]['max_val'] > 2 else 1
         head = _make_head(x, heads, name, relations, dim)
         heads[name] = head
 

--- a/scaaml/io/dataset.py
+++ b/scaaml/io/dataset.py
@@ -553,7 +553,7 @@ class Dataset:
                 max_val = data["max_val"]
                 if max_val == 2:
                     # Binary classification.
-                    v = rec[data["ap"]][data["byte"]]
+                    v = tf.cast(rec[data["ap"]][data["byte"]], dtype=tf.float32)
                 else:
                     # Multiple classes classification.
                     v = tf.one_hot(rec[data["ap"]][data["byte"]], max_val)


### PR DESCRIPTION
In the GPAM code the case of targeting a bit was not handled correctly (it should not be class classification). Moreover it seems that TensorFlow is now doing a type check for multiplication (needed by metrics such as MeanRank).