### PR TITLE
Modernize custom metrics

### DIFF
--- a/scaaml/metrics/custom.py
+++ b/scaaml/metrics/custom.py
@@ -159,7 +159,7 @@ class MeanConfidence(MeanMetricWrapper):  # type: ignore[no-any-unimported,misc]
         result = super().get_config()
         if "fn" in result:
             del result["fn"]
-        return result
+        return result  # type: ignore[no-any-return]
 
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> "MeanConfidence":
@@ -205,7 +205,7 @@ class MeanRank(MeanMetricWrapper):  # type: ignore[no-any-unimported,misc]
         result = super().get_config()
         if "fn" in result:
             del result["fn"]
-        return result
+        return result  # type: ignore[no-any-return]
 
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> "MeanRank":


### PR DESCRIPTION
- Add get_config and from_config methods to custom metrics so that their serialization is automatic and test this. Preventing future occurance of issue mitigated in https://github.com/google/scaaml/pull/299.

- Modernize from TensorFlow only to Keras with multi-backend. By using keras.ops in place of tf functions.

- Remove the parameter `decimals` from MaxRank since it was unused and the original use was showing the metric as an integer (ignored by the training output).

- TODO(low priority): Move from SciPy to allow using SignificanceTest during training.