### PR TITLE
chore: add safe type hints for constants and returns (3 files)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -19,7 +19,7 @@ https://docs.pytest.org/en/latest/example/simple.html#control-skipping-of-tests-
 import pytest
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser) -> None:
     parser.addoption(
         "--run-slow",
         action="store_true",
@@ -28,14 +28,14 @@ def pytest_addoption(parser):
     )
 
 
-def pytest_configure(config):
+def pytest_configure(config) -> None:
     config.addinivalue_line(
         "markers",
         "slow: mark test as slow to run",
     )
 
 
-def pytest_collection_modifyitems(config, items):
+def pytest_collection_modifyitems(config, items) -> None:
     if config.getoption("--run-slow"):
         # --run-slow given in cli: do not skip slow tests
         return

--- a/papers/2024/GPAM/gpam_ecc_cm1.py
+++ b/papers/2024/GPAM/gpam_ecc_cm1.py
@@ -202,7 +202,7 @@ class GAU(layers.Layer):
         self.beta = tf.Variable(lambda: self.ZEROS_INITIALIZER(
             shape=[2, self.shared_dim], dtype=tf.float32))
 
-    def call(self, x, training=False):
+    def call(self, x, training: bool=False):
 
         shortcut = x
         x = self.norm(x)
@@ -510,7 +510,7 @@ def get_model(inputs, outputs, output_relations, trace_len: int,
     return model
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description="Train GPAM model for ECC CM1")
     parser.add_argument(
         "--dataset_path",

--- a/scaaml_intro/train.py
+++ b/scaaml_intro/train.py
@@ -29,7 +29,7 @@ from scaaml.utils import get_num_gpu
 from scaaml.utils import tf_cap_memory
 
 
-def train_model(config):
+def train_model(config) -> None:
     tf_cap_memory()
     algorithm = config["algorithm"]
     train_glob = f"datasets/{algorithm}/train/*"


### PR DESCRIPTION
Hello,

I noticed a few areas where the code could be slightly improved. This PR focuses on minor housekeeping tasks and does not change any of the existing runtime logic:

### Type hint additions
- `conftest.py`: added type hints to 3 function(s)
- `papers/2024/GPAM/gpam_ecc_cm1.py`: added type hints to 2 function(s)
- `scaaml_intro/train.py`: added type hints to 1 function(s)

I have added **strictly conservative** type annotations based only on explicit primitive default values and singular return statements. Complex objects and dynamic references were purposefully ignored to avoid false positives.

### Examples of changes
**Example change in `conftest.py`:**
```diff
-def pytest_addoption(parser):
+def pytest_addoption(parser) -> None:
-def pytest_configure(config):
+def pytest_configure(config) -> None:
-def pytest_collection_modifyitems(config, items):
+def pytest_collection_modifyitems(config, items) -> None:
```
**Example change in `papers/2024/GPAM/gpam_ecc_cm1.py`:**
```diff
-    def call(self, x, training=False):
+    def call(self, x, training: bool=False):
-def main():
+def main() -> None:
```

---
### Verification
- I verified these changes using `ast.parse()` to ensure no syntax errors were introduced.
- I did not modify any `__init__.py` files.

If anything looks incorrect, please feel free to adjust it or close the PR entirely. Thank you for maintaining this project!